### PR TITLE
Feature b199 - email activation

### DIFF
--- a/nova/nova/email_token.py
+++ b/nova/nova/email_token.py
@@ -1,0 +1,10 @@
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils import six
+
+
+class EmailTokenGenerator(PasswordResetTokenGenerator):
+    def _make_hash_value(self, user, timestamp):
+        return six.text_type(user.pk) + six.text_type(timestamp) + six.text_type(user.is_active)
+
+
+account_activation_token = EmailTokenGenerator()

--- a/nova/nova/models.py
+++ b/nova/nova/models.py
@@ -27,6 +27,8 @@ class User(AbstractUser):
 
     following_tr_eqs = models.ManyToManyField('TradingEquipment', 'followers')
 
+    email_activated = models.BooleanField(blank=True, default=False)
+
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['created_at', 'date_of_birth', 'groups', 'first_name', 'last_name']
 

--- a/nova/nova/serializers.py
+++ b/nova/nova/serializers.py
@@ -10,7 +10,7 @@ class UserSerializer(NovaSerializer):
     class Meta:
         model = User
         fields = ['email', 'lat', 'long', 'first_name', 'last_name', 'date_of_birth', 'profile_image', 'password', 'pk',
-                  'groups']
+                  'groups', 'email_activated']
         create_only_fields = ['first_name', 'last_name']
 
     password = serializers.CharField(
@@ -18,6 +18,7 @@ class UserSerializer(NovaSerializer):
         required=True,
         style={'input_type': 'password', 'placeholder': 'Password'}
     )
+
 
     def validate(self, attrs):
         if len(attrs.get('groups', [])) != 1:

--- a/nova/nova/settings.py
+++ b/nova/nova/settings.py
@@ -86,13 +86,13 @@ WSGI_APPLICATION = 'nova.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'mercatus',
-        'USER': 'postgres',
-        'PASSWORD': 'postgres',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'NAME': os.environ.get('MERCATUS_DB_NAME'),
+        'USER': os.environ.get('MERCATUS_DB_USER'),
+        'PASSWORD': os.environ.get('MERCATUS_DB_PASSWORD'),
+        'HOST': os.environ.get('MERCATUS_DB_HOST'),
+        'PORT': os.environ.get('MERCATUS_DB_PORT'),
         'TEST': {
-            'NAME': 'postgres'
+            'NAME': os.environ.get('MERCATUS_TEST_DB_NAME'),
         }
     }
 }

--- a/nova/nova/settings.py
+++ b/nova/nova/settings.py
@@ -39,7 +39,8 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'nova',
-    'corsheaders'
+    'corsheaders',
+    'django_filters'
 ]
 
 MIDDLEWARE = [
@@ -85,13 +86,13 @@ WSGI_APPLICATION = 'nova.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': os.environ.get('MERCATUS_DB_NAME'),
-        'USER': os.environ.get('MERCATUS_DB_USER'),
-        'PASSWORD': os.environ.get('MERCATUS_DB_PASSWORD'),
-        'HOST': os.environ.get('MERCATUS_DB_HOST'),
-        'PORT': os.environ.get('MERCATUS_DB_PORT'),
+        'NAME': 'mercatus',
+        'USER': 'postgres',
+        'PASSWORD': 'postgres',
+        'HOST': 'localhost',
+        'PORT': '5432',
         'TEST': {
-            'NAME': os.environ.get('MERCATUS_TEST_DB_NAME'),
+            'NAME': 'postgres'
         }
     }
 }
@@ -140,6 +141,14 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ],
     'DATE_INPUT_FORMATS': ['iso-8601'],
+    'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
 }
 
 AUTH_USER_MODEL = 'nova.User'
+
+EMAIL_USE_TLS = True
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_HOST_USER = 'mercatus.bounswe@gmail.com'
+# this app password is configured for the host email
+EMAIL_HOST_PASSWORD = 'fnyycxorasikyxkl'
+EMAIL_PORT = 587

--- a/nova/nova/settings.py
+++ b/nova/nova/settings.py
@@ -147,8 +147,7 @@ REST_FRAMEWORK = {
 AUTH_USER_MODEL = 'nova.User'
 
 EMAIL_USE_TLS = True
-EMAIL_HOST = 'smtp.gmail.com'
-EMAIL_HOST_USER = 'mercatus.bounswe@gmail.com'
-# this app password is configured for the host email
-EMAIL_HOST_PASSWORD = 'fnyycxorasikyxkl'
-EMAIL_PORT = 587
+EMAIL_HOST = os.environ.get('MERCATUS_EMAIL_HOST')
+EMAIL_HOST_USER = os.environ.get('MERCATUS_EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.environ.get('MERCATUS_EMAIL_HOST_PASSWORD')
+EMAIL_PORT = os.environ.get('MERCATUS_EMAIL_HOST_PORT')

--- a/nova/nova/urls.py
+++ b/nova/nova/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
 
     path('user_searches', views.user_searches_res),
 
+    path('activations/<uidb64>/<token>', views.activate_account),
 
     path('articles', views.article_coll),
 ]

--- a/nova/nova/views.py
+++ b/nova/nova/views.py
@@ -1,5 +1,7 @@
 from django.contrib.auth import authenticate
 from django.db.models import Q
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from rest_framework import permissions
 from rest_framework import status
 from rest_framework.authtoken.models import Token
@@ -8,9 +10,33 @@ from rest_framework.exceptions import AuthenticationFailed, PermissionDenied, No
 from rest_framework.response import Response
 from django.contrib.postgres.search import SearchQuery, SearchVector, SearchRank, TrigramSimilarity
 
+from nova.email_token import account_activation_token
+
 from .models import User, Article
 from .permissions import IsPostOrIsAuthenticated, is_user_in_group
 from .serializers import UserSerializer, ArticleSerializer
+
+from django.core.mail import EmailMessage
+from django.contrib.sites.shortcuts import get_current_site
+
+from django_filters import rest_framework as filters
+
+
+@api_view(['GET'])
+@permission_classes((permissions.AllowAny,))
+def activate_account(request, uidb64, token):
+    try:
+        uid = force_bytes(urlsafe_base64_decode(uidb64))
+        user = User.objects.get(pk=uid)
+    except(TypeError, ValueError, OverflowError, User.DoesNotExist):
+        user = None
+    if user is not None and account_activation_token.check_token(user, token):
+        user.email_activated = True
+        user.save()
+        serializer = UserSerializer(user)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    else:
+        return Response('Activation link is invalid!', status=status.HTTP_400_BAD_REQUEST)
 
 
 @api_view(['GET', 'POST'])
@@ -25,7 +51,15 @@ def users_coll(request):
         serializer = UserSerializer(data=request.data)
 
         if serializer.is_valid():
-            serializer.save()
+            user = serializer.save()
+            current_site = get_current_site(request)
+            email_subject = 'Mercatus account activation'
+            token = account_activation_token.make_token(user)
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            message = "http://" + str(current_site.domain) + "/activations/" + uid + "/" + token
+            send_to = request.data.get('email')
+            email = EmailMessage(email_subject, message, to=[send_to])
+            email.send()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
@@ -123,7 +157,6 @@ def user_followers_coll(request, pk):
 def auth_tokens_coll(request):
     user = authenticate(request=request,
                         username=request.data.get('email'), password=request.data.get('password'))
-
     if user is None:
         raise AuthenticationFailed()
 

--- a/nova/setup_creds.py
+++ b/nova/setup_creds.py
@@ -11,7 +11,9 @@ def create_dir_if_not_exists(path):
 
 
 CRED_KEYS = ['MERCATUS_DB_NAME', 'MERCATUS_DB_USER', 'MERCATUS_DB_PASSWORD', 'MERCATUS_DB_HOST',
-             'MERCATUS_DB_PORT', 'MERCATUS_TEST_DB_NAME']
+             'MERCATUS_DB_PORT', 'MERCATUS_TEST_DB_NAME',
+             'MERCATUS_EMAIL_HOST', 'MERCATUS_EMAIL_HOST_USER', 'MERCATUS_EMAIL_HOST_PASSWORD',
+             'MERCATUS_EMAIL_HOST_PORT']
 
 CONDA_DIR = os.path.join(os.environ.get("CONDA_PREFIX"), "etc", "conda")
 ACTIVATE_DIR = os.path.join(CONDA_DIR, "activate.d")


### PR DESCRIPTION
### Description
Added email verification system.

### Related Issues
#200 

### Other Comments
Upon registration, an email formatted as 'currentsite/activations/hashed_user_id/hashed_token' sent to the user. Testing at the local, currentsite is the 'localhost:port'. However, after completing the registration from our frontend/mobile, this will be different and the user will be redirected to the frontend/mobile apps after clicking the link. In that step, frontend/mobile clients should send GET request to our backend endpoint (/activations/hashed_user_id/hashed_token),  in order to complete activation.

### Checklist
- [x] Code runs
- [x] Created tests (if applicable)
- [x] All tests passing
- [ ] Extended the README and the documentation (if applicable)
