### PR TITLE
Feature m188

### DIFF
--- a/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/LoginActivity.kt
+++ b/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/LoginActivity.kt
@@ -23,23 +23,15 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
 
-        val sharedPreferences = getSharedPreferences("user_id", Context.MODE_PRIVATE)
+        val sharedPreferences = getSharedPreferences("TOKEN_INFO", Context.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
 
 
-  //      Toast.makeText(
-  //          this@LoginActivity,
-  //          "ASDASD! "+sharedPreferences.getString("user_id"," ") ,
-  //          Toast.LENGTH_SHORT
-  //      ).show()
 
 
-        if(sharedPreferences.getString("user_id"," ") !=" "){
- //           Toast.makeText(
- //               this@LoginActivity,
- //               "ASDASD!"+sharedPreferences.getString("user_id"," ")+sharedPreferences.getString("user_id"," ")!!.length ,
- //               Toast.LENGTH_SHORT
- //           ).show()
+
+        if(sharedPreferences.getString("token"," ") !=" "){
+
             val intent = Intent(this@LoginActivity, MainActivity::class.java)
             startActivity(intent)
             finish()
@@ -133,8 +125,7 @@ class LoginActivity : AppCompatActivity() {
                     editor.putString("user_id", response.body()?.user_id.toString())
                     editor.commit()
 
-                    Toast.makeText(this@LoginActivity, "Login success! my user id is  "+
-                            sharedPreferences2.getString("user_id"," ") ,Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@LoginActivity, "Login success! ",Toast.LENGTH_SHORT).show()
 
                     val intent = Intent(this@LoginActivity, MainActivity::class.java)
                     startActivity(intent)

--- a/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/LoginActivity.kt
+++ b/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/LoginActivity.kt
@@ -23,6 +23,33 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
 
+        val sharedPreferences = getSharedPreferences("user_id", Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+
+
+  //      Toast.makeText(
+  //          this@LoginActivity,
+  //          "ASDASD! "+sharedPreferences.getString("user_id"," ") ,
+  //          Toast.LENGTH_SHORT
+  //      ).show()
+
+
+        if(sharedPreferences.getString("user_id"," ") !=" "){
+ //           Toast.makeText(
+ //               this@LoginActivity,
+ //               "ASDASD!"+sharedPreferences.getString("user_id"," ")+sharedPreferences.getString("user_id"," ")!!.length ,
+ //               Toast.LENGTH_SHORT
+ //           ).show()
+            val intent = Intent(this@LoginActivity, MainActivity::class.java)
+            startActivity(intent)
+            finish()
+        }
+
+
+
+
+
+
         // Button click listener
         buttonSigin.setOnClickListener {
             val email = editMail.text.toString()
@@ -101,11 +128,13 @@ class LoginActivity : AppCompatActivity() {
             }
             override fun onResponse(call: Call<SignInRes>, response: Response<SignInRes>) {
                 if (response.code() == 200) {
+                    val sharedPreferences2 = getSharedPreferences("TOKEN_INFO", Context.MODE_PRIVATE)
                     editor.putString("token", response.body()?.token)
                     editor.putString("user_id", response.body()?.user_id.toString())
-                    editor.apply()
+                    editor.commit()
 
-                    Toast.makeText(this@LoginActivity, "Login success!.", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@LoginActivity, "Login success! my user id is  "+
+                            sharedPreferences2.getString("user_id"," ") ,Toast.LENGTH_SHORT).show()
 
                     val intent = Intent(this@LoginActivity, MainActivity::class.java)
                     startActivity(intent)
@@ -113,6 +142,8 @@ class LoginActivity : AppCompatActivity() {
                             R.anim.slide_in_right,
                     R.anim.slide_out_left
                     )
+
+                    finish()
 
                 } else {
                     Toast.makeText(this@LoginActivity, "Login failed!", Toast.LENGTH_SHORT).show()

--- a/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/MainActivity.kt
+++ b/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : AppCompatActivity() {
         val toolbar: Toolbar = findViewById(com.bounswe.mercatus.R.id.toolbar)
         setSupportActionBar(toolbar)
 
-        val token = getSharedPreferences("user_id", Context.MODE_PRIVATE)
+        val token = getSharedPreferences("TOKEN_INFO", Context.MODE_PRIVATE)
 
         val fab: FloatingActionButton = findViewById(com.bounswe.mercatus.R.id.fab)
         fab.setOnClickListener { view ->
@@ -82,12 +82,16 @@ class MainActivity : AppCompatActivity() {
             msgShow("Successfully logged out")
 
             val intent = Intent(this@MainActivity, LoginActivity::class.java)
-            startActivity(intent)
 
-            val preferences = getSharedPreferences("user_id", Context.MODE_PRIVATE)
+
+
+
+            val preferences = getSharedPreferences("TOKEN_INFO", Context.MODE_PRIVATE)
             val editor = preferences.edit()
-            editor.putString("user_id", " ")
+            editor.putString("token", " ")
             editor.commit()
+
+            startActivity(intent)
             finish()
             true
         }

--- a/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/MainActivity.kt
+++ b/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/MainActivity.kt
@@ -1,8 +1,11 @@
 package com.bounswe.mercatus.Fragments
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
+import android.view.MenuItem
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.drawerlayout.widget.DrawerLayout
@@ -11,9 +14,18 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
-import com.bounswe.mercatus.R
+
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.navigation.NavigationView
+import android.text.method.TextKeyListener.clear
+import android.R.id.edit
+import android.content.SharedPreferences
+import androidx.core.app.ComponentActivity.ExtraData
+import androidx.core.content.ContextCompat.getSystemService
+import android.icu.lang.UCharacter.GraphemeClusterBreak.T
+import android.R
+
+
 
 class MainActivity : AppCompatActivity() {
 
@@ -21,11 +33,13 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-        val toolbar: Toolbar = findViewById(R.id.toolbar)
+        setContentView(com.bounswe.mercatus.R.layout.activity_main)
+        val toolbar: Toolbar = findViewById(com.bounswe.mercatus.R.id.toolbar)
         setSupportActionBar(toolbar)
 
-        val fab: FloatingActionButton = findViewById(R.id.fab)
+        val token = getSharedPreferences("user_id", Context.MODE_PRIVATE)
+
+        val fab: FloatingActionButton = findViewById(com.bounswe.mercatus.R.id.fab)
         fab.setOnClickListener { view ->
             val intent = Intent(this@MainActivity, SearchActivity::class.java)
             startActivity(intent)
@@ -33,19 +47,19 @@ class MainActivity : AppCompatActivity() {
             Smooth activity transition
              */
             overridePendingTransition(
-                R.anim.slide_in_right,
-                R.anim.slide_out_left
+                com.bounswe.mercatus.R.anim.slide_in_right,
+                com.bounswe.mercatus.R.anim.slide_out_left
             )
         }
-        val drawerLayout: DrawerLayout = findViewById(R.id.drawer_layout)
-        val navView: NavigationView = findViewById(R.id.nav_view)
-        val navController = findNavController(R.id.nav_host_fragment)
+        val drawerLayout: DrawerLayout = findViewById(com.bounswe.mercatus.R.id.drawer_layout)
+        val navView: NavigationView = findViewById(com.bounswe.mercatus.R.id.nav_view)
+        val navController = findNavController(com.bounswe.mercatus.R.id.nav_host_fragment)
         // Passing each menu ID as a set of Ids because each
         // menu should be considered as top level destinations.
         appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.nav_home, R.id.nav_gallery, R.id.nav_slideshow,
-                R.id.nav_tools, R.id.nav_share, R.id.nav_send
+                com.bounswe.mercatus.R.id.nav_home, com.bounswe.mercatus.R.id.nav_gallery, com.bounswe.mercatus.R.id.nav_slideshow,
+                com.bounswe.mercatus.R.id.nav_tools, com.bounswe.mercatus.R.id.nav_share, com.bounswe.mercatus.R.id.nav_send
             ), drawerLayout
         )
         setupActionBarWithNavController(navController, appBarConfiguration)
@@ -54,12 +68,43 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         // Inflate the menu; this adds items to the action bar if it is present.
-        menuInflater.inflate(R.menu.main, menu)
+        menuInflater.inflate(com.bounswe.mercatus.R.menu.main, menu)
         return true
     }
 
     override fun onSupportNavigateUp(): Boolean {
-        val navController = findNavController(R.id.nav_host_fragment)
+        val navController = findNavController(com.bounswe.mercatus.R.id.nav_host_fragment)
         return navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
     }
+
+    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
+        com.bounswe.mercatus.R.id.action_logout -> {
+            msgShow("Successfully logged out")
+
+            val intent = Intent(this@MainActivity, LoginActivity::class.java)
+            startActivity(intent)
+
+            val preferences = getSharedPreferences("user_id", Context.MODE_PRIVATE)
+            val editor = preferences.edit()
+            editor.putString("user_id", " ")
+            editor.commit()
+            finish()
+            true
+        }
+        com.bounswe.mercatus.R.id.action_settings -> {
+            msgShow("action_settings button is clicked")
+            true
+        }
+
+        else -> {
+            // If we got here, the user's action was not recognized.
+            // Invoke the superclass to handle it.
+            super.onOptionsItemSelected(item)
+        }
+    }
+
+    fun msgShow(msg: String) {
+        Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
+    }
+
 }

--- a/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/ShowProfileActivity.kt
+++ b/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/ShowProfileActivity.kt
@@ -179,7 +179,7 @@ class ShowProfileActivity : AppCompatActivity() {
                     val followingsList = response.body()?.followers
                     for (item in followingsList!!){
                         if(item.pk == user_id){
-                            follow.setText("Unflow")
+                            follow.setText("Unfollow")
                             follow.setBackgroundColor(ContextCompat.getColor(applicationContext, R.color.red))
                             follow.setOnClickListener {
                                 unfollowUser(user_id, pk)

--- a/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/ShowProfileActivity.kt
+++ b/mobile/Mercatus/app/src/main/java/com/bounswe/mercatus/Fragments/ShowProfileActivity.kt
@@ -90,7 +90,8 @@ class ShowProfileActivity : AppCompatActivity() {
                 if (response.code() == 204) {
                     Toast.makeText(this@ShowProfileActivity, response.body()?.toString(), Toast.LENGTH_SHORT)
                         .show()
-
+                    finish()
+                    startActivity(getIntent())
                 }
                 else  {
                     Toast.makeText(this@ShowProfileActivity, "Following Failed "+response.code(), Toast.LENGTH_SHORT)
@@ -130,7 +131,8 @@ class ShowProfileActivity : AppCompatActivity() {
                 if (response.code() == 200) {
                     Toast.makeText(this@ShowProfileActivity, response.body()?.first_name, Toast.LENGTH_SHORT)
                         .show()
-
+                    finish()
+                    startActivity(getIntent())
                 }
                 else  {
                     Toast.makeText(this@ShowProfileActivity, "Following Failed "+response.code(), Toast.LENGTH_SHORT)

--- a/mobile/Mercatus/app/src/main/res/menu/main.xml
+++ b/mobile/Mercatus/app/src/main/res/menu/main.xml
@@ -6,4 +6,12 @@
         android:orderInCategory="100"
         android:title="@string/action_settings"
         app:showAsAction="never" />
+
+
+    <item
+        android:id="@+id/action_logout"
+        android:orderInCategory="100"
+        android:title="Log out"
+        app:showAsAction="never" />
+
 </menu>


### PR DESCRIPTION
### Description
Remember credential after login, so repetitive logins are not necessary even if the user closed the app.
Logout from the account.
The back button does not direct the login page after login. 
Refresh page after a follow and unfollow user operation.


### Related Issues
#188  

### Other Comments
...

### Checklist
- [ ] Code runs
- [ ] Created tests (if applicable)
- [ ] All tests passing
- [ ] Extended the README and the documentation (if applicable)
