### PR TITLE
Add cronjob decoration to fill parities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 .idea
 .DS_Store
 migrations
+nova/node_modules

--- a/nova/README.md
+++ b/nova/README.md
@@ -27,6 +27,7 @@ Finally, setup and initialize the database by running:
 python manage.py makemigrations nova
 python manage.py migrate
 python manage.py loaddata nova/fixtures/*.json
+python manage.py installtasks
 ``` 
 
 ## Running the Server

--- a/nova/nova/av.py
+++ b/nova/nova/av.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import kronos
 import requests
 from django.utils.timezone import make_aware
 
@@ -46,6 +47,7 @@ def do_request(tr_eq):
     return
 
 
+@kronos.register('*/30 * * * *')
 def fill_parities():
     eq_list = TradingEquipment.objects.all()
     for tr_eq in eq_list:

--- a/nova/nova/settings.py
+++ b/nova/nova/settings.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     'nova',
     'corsheaders',
     'django_filters',
+    'kronos'
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
### Description
Added cronjob decoration, updated .gitignore and readme files. Fill parities command is now executed half-hourly.

### Related Issues
See #248.

### Other Comments
These commands must be executed to start the cron jobs:
```
python manage.py installtasks
sudo /etc/init.d/cron reload
```

### Checklist
- [x] Code runs
- [ ] Created tests (if applicable)
- [ ] All tests passing
- [ ] Extended the README and the documentation (if applicable)
