### PR TITLE
Fix the Incorrect Merge Method Related to the Event API

### DIFF
--- a/nova/nova/libs/parse_event_data.py
+++ b/nova/nova/libs/parse_event_data.py
@@ -24,10 +24,12 @@ def parse_event_data(data, date):
     for match in re.finditer(r"<tr\s*id=\"eventRowId_(.*?)\".*?>.*?</tr>", data):
         row = match.group(0)
 
+        event_datetime = search_captured(r"data-event-datetime=\"(.*?)\"", row).split(" ")
+
         events.append({
-            "time": search_captured(r"js-time\"\s*>(.*?)</td>", row),
             "id": f"{match.group(1)}_{date}",
             "country": search_captured(r"\"ceFlags (.*?)\"", row),
+            "time": event_datetime[1][0:5] if len(event_datetime) > 1 else "",
             "value": clear_value(search_captured(r"id=\"eventActual_\d+\">(.*?)</td>", row)),
             "predicted": clear_value(search_captured(r"id=\"eventForecast_\d+\">(.*?)</td>", row)),
             "name": search_captured(r"data-name\s*=\"(.*?)\"", row),

--- a/nova/nova/libs/parse_event_data.py
+++ b/nova/nova/libs/parse_event_data.py
@@ -26,8 +26,8 @@ def parse_event_data(data, date):
 
         events.append({
             "id": match.group(1),
-            "country": search_captured(r"title=\"(.*?)\"\s+class=\"ceFlags", row),
             "time": search_captured(r"js-time\"\s*>(.*?)</td>", row),
+            "country": search_captured(r"\"ceFlags (.*?)\"", row),
             "value": clear_value(search_captured(r"id=\"eventActual_\d+\">(.*?)</td>", row)),
             "predicted": clear_value(search_captured(r"id=\"eventForecast_\d+\">(.*?)</td>", row)),
             "name": search_captured(r"data-name\s*=\"(.*?)\"", row),

--- a/nova/nova/libs/parse_event_data.py
+++ b/nova/nova/libs/parse_event_data.py
@@ -25,8 +25,8 @@ def parse_event_data(data, date):
         row = match.group(0)
 
         events.append({
-            "id": match.group(1),
             "time": search_captured(r"js-time\"\s*>(.*?)</td>", row),
+            "id": f"{match.group(1)}_{date}",
             "country": search_captured(r"\"ceFlags (.*?)\"", row),
             "value": clear_value(search_captured(r"id=\"eventActual_\d+\">(.*?)</td>", row)),
             "predicted": clear_value(search_captured(r"id=\"eventForecast_\d+\">(.*?)</td>", row)),


### PR DESCRIPTION
### Description
Reimplement #287 

### Related Issues
#295 

### Other comments
Normally, we select the merge method that commits each commit of the branch to master to increase readability of our Git history. By mistake, I merged #287 as a single commit. This PR fixes that.

### Checklist
- [x] Code runs
- [x] Created tests (if applicable)
- [x] All tests passing
- [x] Extended the README and the documentation (if applicable)
