### PR TITLE
Configure Swagger API docs for nova

### DIFF
--- a/nova/README.md
+++ b/nova/README.md
@@ -14,6 +14,7 @@ conda install pillow
 conda install psycopg2
 conda install -c conda-forge django-cors-headers
 conda install requests
+conda install -c conda-forge django-rest-swagger
 ```
 
 Then, create a PostgreSQL database named `mercatus`. Supply the DB credentials to the project by running:

--- a/nova/nova/settings.py
+++ b/nova/nova/settings.py
@@ -40,7 +40,8 @@ INSTALLED_APPS = [
     'rest_framework.authtoken',
     'nova',
     'corsheaders',
-    'django_filters'
+    'django_filters',
+    'rest_framework_swagger'
 ]
 
 MIDDLEWARE = [
@@ -138,13 +139,28 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
         'rest_framework.permissions.AllowAny',
-
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.TokenAuthentication',
     ],
     'DATE_INPUT_FORMATS': ['iso-8601'],
     'DEFAULT_FILTER_BACKENDS': ['django_filters.rest_framework.DjangoFilterBackend'],
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
+}
+
+SWAGGER_SETTINGS = {
+    'DOC_EXPANSION': 'list',
+    'SHOW_REQUEST_HEADERS': True,
+    'USE_SESSION_AUTH': False,
+    'SECURITY_DEFINITIONS': {
+        "api_key": {
+            "type": "apiKey",
+            "name": "Authorization",
+            "in": "header",
+        },
+    },
+    'OPERATIONS_SORTER': 'method',
+    'APIS_SORTER': 'alpha',
 }
 
 AUTH_USER_MODEL = 'nova.User'

--- a/nova/nova/swagger.py
+++ b/nova/nova/swagger.py
@@ -1,0 +1,42 @@
+from rest_framework import exceptions
+from rest_framework.permissions import AllowAny
+from rest_framework.renderers import CoreJSONRenderer
+from rest_framework.response import Response
+from rest_framework.schemas import SchemaGenerator
+from rest_framework.views import APIView
+
+from rest_framework_swagger import renderers
+
+
+def get_swagger_view(title=None, url=None, patterns=None, urlconf=None):
+    """
+    Returns schema view which renders Swagger/OpenAPI.
+    """
+
+    class SwaggerSchemaView(APIView):
+        _ignore_model_permissions = True
+        exclude_from_schema = True
+        permission_classes = [AllowAny]
+        renderer_classes = [
+            CoreJSONRenderer,
+            renderers.OpenAPIRenderer,
+            renderers.SwaggerUIRenderer
+        ]
+
+        def get(self, request):
+            generator = SchemaGenerator(
+                title=title,
+                url=url,
+                patterns=patterns,
+                urlconf=urlconf
+            )
+            schema = generator.get_schema()
+
+            if not schema:
+                raise exceptions.ValidationError(
+                    'The schema generator did not return a schema Document'
+                )
+
+            return Response(schema)
+
+    return SwaggerSchemaView.as_view()

--- a/nova/nova/urls.py
+++ b/nova/nova/urls.py
@@ -1,11 +1,15 @@
 from django.urls import path
 
-from nova.other_views import article_view, trading_eq_view, comment_view, like_view, dislike_view, parity_view, \
+from nova.other_views import article_view, trading_eq_view, comment_view, like_view, dislike_view, \
     events as events_views
 from . import views, nasdaq
+from .swagger import get_swagger_view
 
 urlpatterns = [
+    path('', get_swagger_view(title='Mercatus API Documentation')),
+
     path('users', views.users_coll),
+
     path('users/<int:pk>', views.user_res),
 
     path('users/<int:pk>/followings', views.user_followings_coll),


### PR DESCRIPTION
### Description
Configured Swagger API docs for nova. Check http://localhost:8000.

### Related Issues
#323

### Checklist
- [x] Code runs
- [x] Created tests (if applicable)
- [x] All tests passing
- [ ] Extended the README and the documentation (if applicable)
