### PR TITLE
Implement Annotations API

### DIFF
--- a/nova/nova/models.py
+++ b/nova/nova/models.py
@@ -50,6 +50,21 @@ class Article(models.Model):
     REQUIRED_FIELDS = ['created_at', 'title', 'content']
 
 
+class Annotation(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    owner = models.ForeignKey('User', on_delete=models.CASCADE)
+
+    from_position = models.PositiveIntegerField()
+    to_position = models.PositiveIntegerField()
+
+    article = models.ForeignKey('Article', on_delete=models.CASCADE, related_name='annotations')
+
+    content = models.TextField(default="")
+
+    REQUIRED_FIELDS = ['created_at', 'from_position', 'to_position']
+
+
 class TradingEquipment(models.Model):
     TYPE_CHOICES = (
         ('forex', 'forex'),

--- a/nova/nova/serializers.py
+++ b/nova/nova/serializers.py
@@ -6,7 +6,8 @@ from nova.utils.validators import validate_exists
 from nova.permissions import is_user_in_group
 from .utils.serializers import NovaSerializer
 from .models import User, Article, TradingEquipment, Comment, TradingEquipmentComment, ArticleComment, \
-    Prediction, LikeDislike, ArticleLikeDislike, CommentLikeDislike, Event, Asset, Notification, Order, Portfolio
+    Prediction, LikeDislike, ArticleLikeDislike, CommentLikeDislike, Event, Asset, Notification, Order, Portfolio, \
+    Annotation
 
 
 class UserBasicSerializer(NovaSerializer):
@@ -111,11 +112,21 @@ class UserSerializer(NovaSerializer):
         return super(UserSerializer, self).update(instance, validated_data)
 
 
+class AnnotationSerializer(NovaSerializer):
+    class Meta:
+        model = Annotation
+        fields = ['created_at', 'owner', 'from_position', 'to_position', 'content', 'article', 'pk']
+        create_only_fields = ['created_at', 'owner', 'article']
+
+
 class ArticleSerializer(NovaSerializer):
     class Meta:
         model = Article
-        fields = ['author', 'title', 'content', 'rating', 'pk']
+        fields = ['author', 'title', 'content', 'rating', 'pk', 'annotations']
+        read_only_fields = ['annotations']
         create_only_fields = ['author']
+
+    annotations = AnnotationSerializer(read_only=True, many=True)
 
 
 class CommentSerializer(NovaSerializer):

--- a/nova/nova/urls.py
+++ b/nova/nova/urls.py
@@ -4,9 +4,12 @@ from nova.views import articles as article_views, auth_tokens as auth_token_view
     comments as comment_views, events as event_views, likes as like_views, dislikes as dislike_views, \
     orders as order_views, parities as parity_views, users as user_views, \
     trading_equipments as trading_equipment_views, \
-    portfolios as portfolio_views, assets as asset_views
+    portfolios as portfolio_views, assets as asset_views, \
+    annotations as annotation_views
+
 from nova.internal_views import nasdaq as nasdaq_views
 from nova.internal_views import alphavantage as av_views
+
 from .swagger import get_swagger_view
 
 urlpatterns = [
@@ -84,6 +87,10 @@ urlpatterns = [
 
     # Assets
     path('users/<int:user_pk>/cash', asset_views.cash_coll),
+
+    # Annotations
+    path('articles/<int:article_pk>/annotations', annotation_views.annotations_coll),
+    path('articles/<int:article_pk>/annotations/<int:annotation_pk>', annotation_views.annotation_res),
 
     # TEMPORARY ENDPOINTS FOR TESTS
 

--- a/nova/nova/views/annotations.py
+++ b/nova/nova/views/annotations.py
@@ -1,0 +1,71 @@
+# - annotation --> /articles/<article-id>/annotations POST yaparsa yeni annotation
+# GET yaparsa tüm annotationlar
+# /<ann-id>'ye DELETE yaparsa annotation'ı sil
+
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework import permissions
+
+from nova.models import Article
+from nova.permissions import is_user_in_group
+from nova.serializers import AnnotationSerializer
+from nova.utils.dicts import get_subdict
+
+
+# /articles/<article_pk>/annotations
+@api_view(['GET', 'POST'])
+@permission_classes((permissions.IsAuthenticated,))
+def annotations_coll(request, article_pk):
+    try:
+        article = Article.objects.get(pk=article_pk)
+    except Article.DoesNotExist:
+        raise NotFound()
+
+    if request.method == 'GET':
+        anns = article.annotations.all()
+        serializer = AnnotationSerializer(anns, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    elif request.method == 'POST':
+        serializer = AnnotationSerializer(
+            data={**get_subdict(request.data, ['from_position', 'to_position', 'content']),
+                  'owner': request.user.pk,
+                  'article': article.pk})
+
+        print(serializer)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+# /articles/<article_pk>/annotations/<annotation_pk>
+@api_view(['PUT', 'DELETE', 'GET'])
+@permission_classes((permissions.IsAuthenticated,))
+def annotation_res(request, article_pk, annotation_pk):
+    try:
+        article = Article.objects.get(pk=article_pk)
+        ann = article.annotations.get(pk=annotation_pk)
+    except:
+        raise NotFound()
+
+    serializer = AnnotationSerializer(ann, request.data, partial=True)
+
+    if not serializer.is_valid():
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    if request.method == 'GET':
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    else:
+        if (not is_user_in_group(request.user, "admin")) and ann.owner.pk != request.user.pk:
+            raise PermissionDenied()
+
+        if request.method == 'PUT':
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        elif request.method == 'DELETE':
+            ann.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
### Description
Implements the annotations API that has endpoints for listing annotations, creating annotations,
retrieving annotations, deleting annotations, updating annotations.

This PR also implements annotations model and the serializer.

### Related Issues
#338 

### Other Comments
See the updated Postman docs for a summary of new endpoints and example calls.

### Checklist
- [x] Code runs
- [x] Created tests (if applicable)
- [x] All tests passing
- [x] Extended the README and the documentation (if applicable)
